### PR TITLE
README: Add link to Apache Cordova CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Then in another terminal tab:
 lein run
 ```
 
-Then in a third tab:
+Be sure to have the [Apache Cordova CLI](http://cordova.apache.org/docs/en/5.0.0/guide_cli_index.md.html) installed and then in a third tab:
 
 ```
 cd resources


### PR DESCRIPTION
Having the Apache Cordova CLI installed is a requirement. A link in the readme might be of help to some people like me who don't have cordova already installed :)
